### PR TITLE
Use tempfile for tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,6 @@ failure = "0.1.3"
 flate2 = "1.0"
 enum_primitive = "0.1.1"
 xz2 = { version = "0.1", optional = true }
+
+[dev-dependencies]
+tempfile = "3"


### PR DESCRIPTION
Use the `tempfile` crate instead of hardcoding temporary file names.