### PR TITLE
Run checks on all PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [master]
   pull_request:
-    branches: [master]
+    branches: ["**"]
 
 jobs:
   check:


### PR DESCRIPTION
Initial CI setup only build PRs on `master`, changing this to build on every PR.