### PR TITLE
Feature testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,11 +85,20 @@ jobs:
           toolchain: nightly
           override: true
 
-      - name: Run tests
+      - name: Run tests without default features
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --no-fail-fast
+          args: --no-fail-fast --all --no-default-features
+        env:
+          'CARGO_INCREMENTAL': '0'
+          'RUSTFLAGS': '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads'
+
+      - name: Run tests for all features
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-fail-fast --all --all-features
         env:
           'CARGO_INCREMENTAL': '0'
           'RUSTFLAGS': '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads'

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,11 +227,43 @@ mod test {
             let result = read_compression(Box::new(SHORT_FILE));
             assert!(result.is_err());
         }
+
+        #[test]
+        fn no_compression() {
+            let (compression, _) =
+                read_compression(Box::new(LOREM_IPSUM)).expect("Error in read file");
+            assert_eq!(compression, CompressionFormat::No);
+        }
     }
 
     mod compress_uncompress {
         use super::*;
         use tempfile::NamedTempFile;
+
+        #[test]
+        fn no_compression() {
+            let ofile = NamedTempFile::new().expect("Can't create tmpfile");
+
+            {
+                let wfile = ofile.reopen().expect("Can't create tmpfile");
+                let mut writer = get_writer(Box::new(wfile), CompressionFormat::No).unwrap();
+                writer
+                    .write_all(LOREM_IPSUM)
+                    .expect("Error during write of data");
+            }
+
+            let rfile = ofile.reopen().expect("Can't create tmpfile");
+            let (mut reader, compression) =
+                get_reader(Box::new(rfile)).expect("Error reading from tmpfile");
+
+            assert_eq!(compression, CompressionFormat::No);
+
+            let mut buffer = Vec::new();
+            reader
+                .read_to_end(&mut buffer)
+                .expect("Error during reading");
+            assert_eq!(LOREM_IPSUM, buffer.as_slice());
+        }
 
         #[test]
         fn gzip() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,6 +265,11 @@ mod test {
                 get_writer(Box::new(vec![]), CompressionFormat::Bzip).is_err(),
                 "bz2 disabled, this assertion should fail"
             );
+
+            assert!(
+                get_reader(Box::new(&BZIP_FILE[..])).is_err(),
+                "bz2 disabled, this assertion should fail"
+            );
         }
 
         #[cfg(feature = "bz2")]
@@ -298,6 +303,11 @@ mod test {
         fn no_lzma_feature() {
             assert!(
                 get_writer(Box::new(vec![]), CompressionFormat::Lzma).is_err(),
+                "lzma disabled, this assertion should fail"
+            );
+
+            assert!(
+                get_reader(Box::new(&LZMA_FILE[..])).is_err(),
                 "lzma disabled, this assertion should fail"
             );
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,6 +258,15 @@ mod test {
             assert_eq!(LOREM_IPSUM, buffer.as_slice());
         }
 
+        #[test]
+        #[cfg(not(feature = "bz2"))]
+        fn no_bzip2_feature() {
+            assert!(
+                get_writer(Box::new(vec![]), CompressionFormat::Bzip).is_err(),
+                "bz2 disabled, this assertion should fail"
+            );
+        }
+
         #[cfg(feature = "bz2")]
         #[test]
         fn bzip() {
@@ -282,6 +291,15 @@ mod test {
                 .read_to_end(&mut buffer)
                 .expect("Error during reading");
             assert_eq!(LOREM_IPSUM, buffer.as_slice());
+        }
+
+        #[test]
+        #[cfg(not(feature = "lzma"))]
+        fn no_lzma_feature() {
+            assert!(
+                get_writer(Box::new(vec![]), CompressionFormat::Lzma).is_err(),
+                "lzma disabled, this assertion should fail"
+            );
         }
 
         #[cfg(feature = "lzma")]


### PR DESCRIPTION
Adding some extra jobs for CI:
- Run coverage with all features enabled
- Run coverage without default features

This helps guarantee more of the [features rules](https://doc.rust-lang.org/cargo/reference/manifest.html#rules).

Also add two tests for checking the error returned from `get_writer` when features are disabled.