### PR TITLE
Add from/to path functions

### DIFF
--- a/src/compression.rs
+++ b/src/compression.rs
@@ -57,7 +57,9 @@ pub enum Level {
     Nine,
 }
 
-fn get_first_five(mut in_stream: Box<dyn io::Read>) -> Result<([u8; 5], Box<dyn io::Read>), Error> {
+fn get_first_five<'a>(
+    mut in_stream: Box<dyn io::Read + 'a>,
+) -> Result<([u8; 5], Box<dyn io::Read + 'a>), Error> {
     let mut buf = [0u8; 5];
     match in_stream.read_exact(&mut buf) {
         Ok(()) => Ok((buf, in_stream)),
@@ -65,9 +67,9 @@ fn get_first_five(mut in_stream: Box<dyn io::Read>) -> Result<([u8; 5], Box<dyn 
     }
 }
 
-pub(crate) fn read_compression(
-    in_stream: Box<dyn io::Read>,
-) -> Result<(Format, Box<dyn io::Read>), Error> {
+pub(crate) fn read_compression<'a>(
+    in_stream: Box<dyn io::Read + 'a>,
+) -> Result<(Format, Box<dyn io::Read + 'a>), Error> {
     let (first_bytes, in_stream) = get_first_five(in_stream)?;
 
     let mut five_bit_val: u64 = 0;
@@ -96,27 +98,27 @@ pub(crate) fn read_compression(
 
 cfg_if! {
     if #[cfg(feature = "bz2")] {
-        pub(crate) fn new_bz2_encoder(out: Box<dyn io::Write>, level: Level) -> Result<Box<dyn io::Write>, Error> {
+        pub(crate) fn new_bz2_encoder<'a>(out: Box<dyn io::Write + 'a>, level: Level) -> Result<Box<dyn io::Write + 'a>, Error> {
             Ok(Box::new(bzip2::write::BzEncoder::new(
                 out,
                 level.into(),
             )))
         }
 
-        pub(crate) fn new_bz2_decoder(
-            inp: Box<dyn io::Read>,
-        ) -> Result<(Box<dyn io::Read>, Format), Error> {
+        pub(crate) fn new_bz2_decoder<'a>(
+            inp: Box<dyn io::Read + 'a>,
+        ) -> Result<(Box<dyn io::Read + 'a>, Format), Error> {
             Ok((
                 Box::new(bzip2::read::BzDecoder::new(inp)),
                 Format::Bzip,
             ))
         }
     } else {
-        pub(crate) fn new_bz2_encoder(_: Box<dyn io::Write>, _: Level) -> Result<Box<dyn io::Write>, Error> {
+        pub(crate) fn new_bz2_encoder<'a>(_: Box<dyn io::Write + 'a>, _: Level) -> Result<Box<dyn io::Write + 'a>, Error> {
             Err(Error::FeatureDisabled)
         }
 
-        pub(crate) fn new_bz2_decoder(_: Box<dyn io::Read>) -> Result<(Box<dyn io::Read>, Format), Error> {
+        pub(crate) fn new_bz2_decoder<'a>(_: Box<dyn io::Read + 'a>) -> Result<(Box<dyn io::Read + 'a>, Format), Error> {
             Err(Error::FeatureDisabled)
         }
     }
@@ -124,24 +126,24 @@ cfg_if! {
 
 cfg_if! {
     if #[cfg(feature = "lzma")] {
-      pub(crate) fn new_lzma_encoder(out: Box<dyn io::Write>, level: Level) -> Result<Box<dyn io::Write>, Error> {
+      pub(crate) fn new_lzma_encoder<'a>(out: Box<dyn io::Write + 'a>, level: Level) -> Result<Box<dyn io::Write + 'a>, Error> {
           Ok(Box::new(xz2::write::XzEncoder::new(out, level.into())))
       }
 
-      pub(crate) fn new_lzma_decoder(
-          inp: Box<dyn io::Read>,
-      ) -> Result<(Box<dyn io::Read>, Format), Error> {
+      pub(crate) fn new_lzma_decoder<'a>(
+          inp: Box<dyn io::Read + 'a>,
+      ) -> Result<(Box<dyn io::Read + 'a>, Format), Error> {
           Ok((
               Box::new(xz2::read::XzDecoder::new(inp)),
               Format::Lzma,
           ))
       }
     } else {
-      pub(crate) fn new_lzma_encoder(_: Box<dyn io::Write>, _: Level) -> Result<Box<dyn io::Write>, Error> {
+      pub(crate) fn new_lzma_encoder<'a>(_: Box<dyn io::Write + 'a>, _: Level) -> Result<Box<dyn io::Write + 'a>, Error> {
           Err(Error::FeatureDisabled)
       }
 
-      pub(crate) fn new_lzma_decoder(_: Box<dyn io::Read>) -> Result<(Box<dyn io::Read>, Format), Error> {
+      pub(crate) fn new_lzma_decoder<'a>(_: Box<dyn io::Read + 'a>) -> Result<(Box<dyn io::Read + 'a>, Format), Error> {
           Err(Error::FeatureDisabled)
       }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,4 +7,7 @@ pub enum Error {
 
     #[error("File is too short, less than five bytes")]
     FileTooShort,
+
+    #[error("I/O error")]
+    IOError(#[from] std::io::Error),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,9 +60,9 @@ pub mod error;
 
 pub use crate::error::Error;
 
-pub fn get_reader(
-    in_stream: Box<dyn io::Read>,
-) -> Result<(Box<dyn io::Read>, compression::Format), Error> {
+pub fn get_reader<'a>(
+    in_stream: Box<dyn io::Read + 'a>,
+) -> Result<(Box<dyn io::Read + 'a>, compression::Format), Error> {
     // check compression
     let (compression, in_stream) = compression::read_compression(in_stream)?;
 
@@ -78,11 +78,11 @@ pub fn get_reader(
     }
 }
 
-pub fn get_writer(
-    out_stream: Box<dyn io::Write>,
+pub fn get_writer<'a>(
+    out_stream: Box<dyn io::Write + 'a>,
     format: compression::Format,
     level: compression::Level,
-) -> Result<Box<dyn io::Write>, Error> {
+) -> Result<Box<dyn io::Write + 'a>, Error> {
     match format {
         compression::Format::Gzip => Ok(Box::new(flate2::write::GzEncoder::new(
             out_stream,
@@ -115,9 +115,9 @@ pub fn get_writer(
 /// # Ok(())
 /// # }
 /// ```
-pub fn from_path<P: AsRef<Path>>(
+pub fn from_path<'a, P: AsRef<Path>>(
     path: P,
-) -> Result<(Box<dyn io::Read>, compression::Format), Error> {
+) -> Result<(Box<dyn io::Read + 'a>, compression::Format), Error> {
     let readable = io::BufReader::new(std::fs::File::open(path)?);
     get_reader(Box::new(readable))
 }
@@ -141,11 +141,11 @@ pub fn from_path<P: AsRef<Path>>(
 /// # Ok(())
 /// # }
 /// ```
-pub fn to_path<P: AsRef<Path>>(
+pub fn to_path<'a, P: AsRef<Path>>(
     path: P,
     format: compression::Format,
     level: compression::Level,
-) -> Result<Box<dyn io::Write>, Error> {
+) -> Result<Box<dyn io::Write + 'a>, Error> {
     let writable = io::BufWriter::new(std::fs::File::create(path)?);
     get_writer(Box::new(writable), format, level)
 }


### PR DESCRIPTION
Per https://github.com/luizirber/niffler/issues/1#issuecomment-565130377

Missing:
- [ ] stdin (as `-`) support
- [ ] docs
- [ ] tests

Questions:
- [ ] Do we want to do format detection for outputs based on path name? In this case `to_path` should take `Format` and `Level` as `Option`s.
- [ ] Bikeshed on function name? `from_path` is quite common in Rust codebases, but not very happy with `to_path`...
- [ ] also use `-` in `to_path` as shortcut for `stdout`?

/cc @enormandeau 