### PR TITLE
Use &mut in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Many similar projects exist in other languages:
 - C: [rbread](https://github.com/ocxtal/rbread)
 - Python: [xphyle](https://github.com/jdidion/xphyle)
 - Perl: [AnyUncompress](https://perldoc.perl.org/IO/Uncompress/AnyUncompress.html)
+- go: [Archiver](https://github.com/mholt/archiver)
 
 
 ## License


### PR DESCRIPTION
I changed the docs a bit, so it uses `Box::new(&mut buf)` following the [API guidelines](https://rust-lang.github.io/api-guidelines/interoperability.html#generic-readerwriter-functions-take-r-read-and-w-write-by-value-c-rw-value) (and because I always messes it up and forget the `&mut` part, so it is good to have it as a reminder =])

This also makes it possible to test the `get_writer` docs without resorting to temporary files.