### PR TITLE
[CI] Replace coverage with tarpaulin

### DIFF
--- a/.github/actions-rs/grcov.yml
+++ b/.github/actions-rs/grcov.yml
@@ -1,7 +1,0 @@
-branch: true
-ignore-not-existing: true
-llvm: true
-filter: covered
-output-type: lcov
-output-file: ./lcov.info
-prefix-dir: /home/user/build/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,33 +85,16 @@ jobs:
           toolchain: nightly
           override: true
 
-      - name: Run tests without default features
-        uses: actions-rs/cargo@v1
+      - name: Run cargo-tarpaulin
+        uses: actions-rs/tarpaulin@v0.1.2
         with:
-          command: test
-          args: --no-fail-fast --all --no-default-features
-        env:
-          'CARGO_INCREMENTAL': '0'
-          'RUSTFLAGS': '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
-
-      - name: Run tests for all features
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --no-fail-fast --all --all-features
-        env:
-          'CARGO_INCREMENTAL': '0'
-          'RUSTFLAGS': '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
-
-      - name: Collect coverage and generate report with grcov
-        uses: actions-rs/grcov@v0.1.4
-        id: coverage
+          version: '0.9.0'
+          args: '-- --test-threads 1'
 
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v1.0.3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ${{ steps.coverage.outputs.report }}
 
   lints:
     name: Lints


### PR DESCRIPTION
Coverage with grcov depends on `nightly`, which is hard to maintain over time (it broke for #22 because the feature changed in `rustc`, for example). This PR uses [actions-rs/tarpaulin](https://github.com/actions-rs/tarpaulin/) instead.