### PR TITLE
Replace GzDecoder with MultiGzDecoder

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,7 +160,7 @@ pub fn get_reader<'a>(
     // return readable and compression status
     match compression {
         compression::Format::Gzip => Ok((
-            Box::new(flate2::read::GzDecoder::new(in_stream)),
+            Box::new(flate2::read::MultiGzDecoder::new(in_stream)),
             compression::Format::Gzip,
         )),
         compression::Format::Bzip => compression::new_bz2_decoder(in_stream),


### PR DESCRIPTION
Fixes #27 

From checking the `flate2` code the only difference between `GzDecoder` and `MultiGzDecoder` is a [`.multi(true)`](https://github.com/alexcrichton/flate2-rs/blob/69ff34a476d6c1f7f74ff1f91608766e2d7cfa51/src/gz/bufread.rs#L588) flag for `GzDecoder` that keeps decoding data after the first member is finished, so it should be safe to replace it (and it doesn't break any `niffler` dependants, since it is exposed as a `Box<dyn io::Read>` anyway).