### PR TITLE
Document how to use features in README and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Document how to use features in README and docs (#32)
+
 ## [2.2.0] - 2020-07-01
 
 ### Changed
 
-- Make gz compression optional too, matching behavior of other compression formats.
+- Make gz compression optional too, matching behavior of other compression formats (#29)
 
 ## [2.1.1] - 2020-06-30
 
 ### Changed
 
-- Replace `GzDecoder` with `MultiGzDecoder` for gzip decompression.
+- Replace `GzDecoder` with `MultiGzDecoder` for gzip decompression (#28)
 
 ## [2.1.0] - 2020-06-06
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/niffler"
 edition = "2018"
 
 [features]
-default = ["bzip2", "xz2", "gz"]
+default = ["bz2", "lzma", "gz"]
 bz2 = ["bzip2"]
 lzma = ["xz2"]
 gz = ["flate2"]

--- a/README.md
+++ b/README.md
@@ -19,6 +19,24 @@ bioinformatics workflows.
 [build-status]: https://github.com/luizirber/niffler/workflows/CI/badge.svg
 [github-actions]: https://github.com/luizirber/niffler/actions?query=workflow%3ACI
 
+## Selecting compression formats
+
+By default all supported compression formats are enabled.
+If you're working on systems that don't support them you can disable default
+features and select the ones you want.
+For example,
+currently only `gz` is supported in Webassembly environments
+(because `niffler` depends on crates that have system dependencies for `bz2` and `lzma` compression),
+so you can use this in your `Cargo.toml` to select only the `gz` support:
+```
+niffler = { version = "2.2.0", default-features = false, features = ["gz"] }
+```
+
+You can still use `niffler::sniff()` to find what is the compression format,
+even if any feature is disabled.
+But if you try to use `niffler::get_reader` for a disabled feature,
+it will throw a runtime error.
+
 ## Similar project
 
 Many similar projects exist in other languages:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,24 @@ Originally from https://github.com/natir/yacrd/blob/3fc6ef8b5b51256f0c4bc45b8056
 //! # Ok(())
 //! # }
 //! ```
+//!
+//! ## Selecting compression formats
+//!
+//! By default all supported compression formats are enabled.
+//! If you're working on systems that don't support them you can disable default
+//! features and select the ones you want.
+//! For example,
+//! currently only `gz` is supported in Webassembly environments
+//! (because `niffler` depends on crates that have system dependencies for `bz2` and `lzma` compression),
+//! so you can use this in your `Cargo.toml` to select only the `gz` support:
+//! ```
+//! niffler = { version = "2.2.0", default-features = false, features = ["gz"] }
+//! ```
+//!
+//! You can still use `niffler::sniff()` to find what is the compression format,
+//! even if any feature is disabled.
+//! But if you try to use `niffler::get_reader` for a disabled feature,
+//! it will throw a runtime error.
 
 /* standard use */
 use std::io;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ Originally from https://github.com/natir/yacrd/blob/3fc6ef8b5b51256f0c4bc45b8056
 //! currently only `gz` is supported in Webassembly environments
 //! (because `niffler` depends on crates that have system dependencies for `bz2` and `lzma` compression),
 //! so you can use this in your `Cargo.toml` to select only the `gz` support:
-//! ```
+//! ```toml
 //! niffler = { version = "2.2.0", default-features = false, features = ["gz"] }
 //! ```
 //!


### PR DESCRIPTION
Fixes #31 

I also fixed `Cargo.toml` to set the default features to actual feature names (instead of the crate names), because even I was getting confused. This also matches the features names used in the code now.