### PR TITLE
CI: add minimum supported Rust version check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -149,3 +149,22 @@ jobs:
         with:
           command: publish
           args: --dry-run
+
+  minimum_rust_version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.37.0
+          override: true
+
+      - name: check if README matches MSRV defined here
+        run: grep '1.37.0' README.md
+
+      - name: Run tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all-features --no-fail-fast

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ even if any feature is disabled.
 But if you try to use `niffler::get_reader` for a disabled feature,
 it will throw a runtime error.
 
+## Minimum supported Rust version
+
+Currently the minimum supported Rust version is 1.37.0.
+
 ## Similar project
 
 Many similar projects exist in other languages:


### PR DESCRIPTION
I wasn't sure if PR #33 would raise the minimum supported Rust version (MSRV), so I added a check in GH Actions. This way we don't need to worry about it for most cases when dependabot updates dependencies.

Ready for review and merge @natir 