### PR TITLE
add Send bounds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "niffler"
-version = "2.2.0"
+version = "3.0.0"
 authors = ["Pierre Marijon <pierre.marijon@inria.fr>", "Luiz Irber <luiz.irber@gmail.com>"]
 description = "Simple and transparent support for compressed files"
 license = "MIT/Apache-2.0"

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -63,8 +63,8 @@ pub enum Level {
 }
 
 pub(crate) fn get_first_five<'a>(
-    mut in_stream: Box<dyn io::Read + 'a>,
-) -> Result<([u8; 5], Box<dyn io::Read + 'a>), Error> {
+    mut in_stream: Box<dyn io::Read + Send + 'a>,
+) -> Result<([u8; 5], Box<dyn io::Read + Send + 'a>), Error> {
     let mut buf = [0u8; 5];
     match in_stream.read_exact(&mut buf) {
         Ok(()) => Ok((buf, in_stream)),
@@ -74,7 +74,7 @@ pub(crate) fn get_first_five<'a>(
 
 cfg_if! {
     if #[cfg(feature = "gz")] {
-        pub(crate) fn new_gz_encoder<'a>(out: Box<dyn io::Write + 'a>, level: Level) -> Result<Box<dyn io::Write + 'a>, Error> {
+        pub(crate) fn new_gz_encoder<'a>(out: Box<dyn io::Write + Send + 'a>, level: Level) -> Result<Box<dyn io::Write + Send + 'a>, Error> {
           Ok(Box::new(flate2::write::GzEncoder::new(
             out,
             level.into(),
@@ -82,18 +82,18 @@ cfg_if! {
         }
 
         pub(crate) fn new_gz_decoder<'a>(
-            inp: Box<dyn io::Read + 'a>,
-        ) -> Result<(Box<dyn io::Read + 'a>, Format), Error> {
+            inp: Box<dyn io::Read + Send + 'a>,
+        ) -> Result<(Box<dyn io::Read + Send + 'a>, Format), Error> {
           Ok((
             Box::new(flate2::read::MultiGzDecoder::new(inp)),
             Format::Gzip,
           ))
         }
     } else {
-        pub(crate) fn new_gz_encoder<'a>(_: Box<dyn io::Write + 'a>, _: Level) -> Result<Box<dyn io::Write + 'a>, Error> {
+        pub(crate) fn new_gz_encoder<'a>(_: Box<dyn io::Write + Send + 'a>, _: Level) -> Result<Box<dyn io::Write + Send + 'a>, Error> {
             Err(Error::FeatureDisabled)
         }
-        pub(crate) fn new_gz_decoder<'a>(_: Box<dyn io::Read + 'a>) -> Result<(Box<dyn io::Read + 'a>, Format), Error> {
+        pub(crate) fn new_gz_decoder<'a>(_: Box<dyn io::Read + Send + 'a>) -> Result<(Box<dyn io::Read + Send + 'a>, Format), Error> {
             Err(Error::FeatureDisabled)
         }
 }
@@ -101,7 +101,7 @@ cfg_if! {
 
 cfg_if! {
     if #[cfg(feature = "bz2")] {
-        pub(crate) fn new_bz2_encoder<'a>(out: Box<dyn io::Write + 'a>, level: Level) -> Result<Box<dyn io::Write + 'a>, Error> {
+        pub(crate) fn new_bz2_encoder<'a>(out: Box<dyn io::Write + Send + 'a>, level: Level) -> Result<Box<dyn io::Write + Send + 'a>, Error> {
             Ok(Box::new(bzip2::write::BzEncoder::new(
                 out,
                 level.into(),
@@ -109,19 +109,19 @@ cfg_if! {
         }
 
         pub(crate) fn new_bz2_decoder<'a>(
-            inp: Box<dyn io::Read + 'a>,
-        ) -> Result<(Box<dyn io::Read + 'a>, Format), Error> {
+            inp: Box<dyn io::Read + Send + 'a>,
+        ) -> Result<(Box<dyn io::Read + Send + 'a>, Format), Error> {
             Ok((
                 Box::new(bzip2::read::BzDecoder::new(inp)),
                 Format::Bzip,
             ))
         }
     } else {
-        pub(crate) fn new_bz2_encoder<'a>(_: Box<dyn io::Write + 'a>, _: Level) -> Result<Box<dyn io::Write + 'a>, Error> {
+        pub(crate) fn new_bz2_encoder<'a>(_: Box<dyn io::Write + Send + 'a>, _: Level) -> Result<Box<dyn io::Write + Send + 'a>, Error> {
             Err(Error::FeatureDisabled)
         }
 
-        pub(crate) fn new_bz2_decoder<'a>(_: Box<dyn io::Read + 'a>) -> Result<(Box<dyn io::Read + 'a>, Format), Error> {
+        pub(crate) fn new_bz2_decoder<'a>(_: Box<dyn io::Read + Send + 'a>) -> Result<(Box<dyn io::Read + Send + 'a>, Format), Error> {
             Err(Error::FeatureDisabled)
         }
     }
@@ -129,24 +129,24 @@ cfg_if! {
 
 cfg_if! {
     if #[cfg(feature = "lzma")] {
-      pub(crate) fn new_lzma_encoder<'a>(out: Box<dyn io::Write + 'a>, level: Level) -> Result<Box<dyn io::Write + 'a>, Error> {
+      pub(crate) fn new_lzma_encoder<'a>(out: Box<dyn io::Write + Send + 'a>, level: Level) -> Result<Box<dyn io::Write + Send + 'a>, Error> {
           Ok(Box::new(xz2::write::XzEncoder::new(out, level.into())))
       }
 
       pub(crate) fn new_lzma_decoder<'a>(
-          inp: Box<dyn io::Read + 'a>,
-      ) -> Result<(Box<dyn io::Read + 'a>, Format), Error> {
+          inp: Box<dyn io::Read + Send + 'a>,
+      ) -> Result<(Box<dyn io::Read + Send + 'a>, Format), Error> {
           Ok((
               Box::new(xz2::read::XzDecoder::new(inp)),
               Format::Lzma,
           ))
       }
     } else {
-      pub(crate) fn new_lzma_encoder<'a>(_: Box<dyn io::Write + 'a>, _: Level) -> Result<Box<dyn io::Write + 'a>, Error> {
+      pub(crate) fn new_lzma_encoder<'a>(_: Box<dyn io::Write + Send + 'a>, _: Level) -> Result<Box<dyn io::Write + Send + 'a>, Error> {
           Err(Error::FeatureDisabled)
       }
 
-      pub(crate) fn new_lzma_decoder<'a>(_: Box<dyn io::Read + 'a>) -> Result<(Box<dyn io::Read + 'a>, Format), Error> {
+      pub(crate) fn new_lzma_decoder<'a>(_: Box<dyn io::Read + Send + 'a>) -> Result<(Box<dyn io::Read + Send + 'a>, Format), Error> {
           Err(Error::FeatureDisabled)
       }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,8 +118,8 @@ pub use crate::error::Error;
 /// # }
 /// ```
 pub fn sniff<'a>(
-    in_stream: Box<dyn io::Read + 'a>,
-) -> Result<(Box<dyn io::Read + 'a>, compression::Format), Error> {
+    in_stream: Box<dyn io::Read + Send + 'a>,
+) -> Result<(Box<dyn io::Read + Send + 'a>, compression::Format), Error> {
     let (first_bytes, in_stream) = compression::get_first_five(in_stream)?;
 
     let mut five_bit_val: u64 = 0;
@@ -173,8 +173,8 @@ pub fn sniff<'a>(
 /// # }
 /// ```
 pub fn get_reader<'a>(
-    in_stream: Box<dyn io::Read + 'a>,
-) -> Result<(Box<dyn io::Read + 'a>, compression::Format), Error> {
+    in_stream: Box<dyn io::Read + Send + 'a>,
+) -> Result<(Box<dyn io::Read + Send + 'a>, compression::Format), Error> {
     // check compression
     let (in_stream, compression) = sniff(in_stream)?;
 
@@ -216,10 +216,10 @@ pub fn get_reader<'a>(
 /// ```
 
 pub fn get_writer<'a>(
-    out_stream: Box<dyn io::Write + 'a>,
+    out_stream: Box<dyn io::Write + Send + 'a>,
     format: compression::Format,
     level: compression::Level,
-) -> Result<Box<dyn io::Write + 'a>, Error> {
+) -> Result<Box<dyn io::Write + Send + 'a>, Error> {
     match format {
         compression::Format::Gzip => compression::new_gz_encoder(out_stream, level),
         compression::Format::Bzip => compression::new_bz2_encoder(out_stream, level),
@@ -253,7 +253,7 @@ pub fn get_writer<'a>(
 /// ```
 pub fn from_path<'a, P: AsRef<Path>>(
     path: P,
-) -> Result<(Box<dyn io::Read + 'a>, compression::Format), Error> {
+) -> Result<(Box<dyn io::Read + Send + 'a>, compression::Format), Error> {
     let readable = io::BufReader::new(std::fs::File::open(path)?);
     get_reader(Box::new(readable))
 }
@@ -283,7 +283,7 @@ pub fn to_path<'a, P: AsRef<Path>>(
     path: P,
     format: compression::Format,
     level: compression::Level,
-) -> Result<Box<dyn io::Write + 'a>, Error> {
+) -> Result<Box<dyn io::Write + Send + 'a>, Error> {
     let writable = io::BufWriter::new(std::fs::File::create(path)?);
     get_writer(Box::new(writable), format, level)
 }


### PR DESCRIPTION
needletail [had to rollback](https://github.com/onecodex/needletail/pull/47#issuecomment-655009389) niffler adoption because PyO3 requires a Send bound. This PR adds `Send` bounds to all places where a `Box<dyn Read>` or `Box<dyn Write>` is used, and... it all passes the tests?

So, what are the drawbacks of adding `Send`? Other than requiring bumping niffler to `3.0.0`? =P

(similar discussion: https://fasterthanli.me/articles/getting-in-and-out-of-trouble-with-rust-futures)

