### PR TITLE
Bump MSRV to 1.51

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -157,11 +157,11 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.42.0
+          toolchain: 1.51.0
           override: true
 
       - name: check if README matches MSRV defined here
-        run: grep '1.42.0' README.md
+        run: grep '1.51.0' README.md
 
       - name: Run tests
         uses: actions-rs/cargo@v1

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ it will throw a runtime error.
 
 ## Minimum supported Rust version
 
-Currently the minimum supported Rust version is 1.42.0.
+Currently the minimum supported Rust version is 1.51.0.
 
 ## Similar project
 


### PR DESCRIPTION
Due to minimal support rust version of a dependency of dependency we must move to rust 1.51.