### PR TITLE
Add feature to allow user to select features of backend

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -155,11 +155,11 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.51.0
+          toolchain: 1.56.1
           override: true
 
       - name: check if README matches MSRV defined here
-        run: grep '1.51.0' README.md
+        run: grep '1.56.1' README.md
 
       - name: Run tests
         uses: actions-rs/cargo@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add continuous deployment workflow (#57)
+- Add features to allow user to select features of backend (#54)
+
+### Changed
+
+- Bump MSRV to 1.56.1 (#54)
+
+### Fixed
+
+- Deduplicate implementation of get_first_{bytes|five} functions (#52)
+
 ## [2.4.0] - 2021-12-25
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,22 @@ gz = ["flate2"]
 bgz = ["bgzip"]
 xz = ["lzma"]
 
+# bzip2 feature transitivity
+bz2_tokio = ["bzip2/tokio"]
+bz2_static = ["bzip2/static"]
+
+# lzma feature transitivity
+lzma_tokio = ["xz2/tokio"]
+
+# flate2 feature transitivity
+gz_zlib = ["flate2/zlib"]
+gz_zlib-ng-compat = ["flate2/zlib-ng-compat"]
+gz_cloudflare_zlib = ["flate2/cloudflare_zlib"]
+gz_rust_backend = ["flate2/rust_backend"]
+
+# xz feature transitivity
+xz_tokio = ["xz2/tokio"]
+
 [dependencies]
 cfg-if = "1.0"
 thiserror = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,3 +65,23 @@ required-features = ["bz2"]
 name = "lzma"
 harness = false
 required-features = ["xz2"]
+
+
+[package.metadata.cargo-all-features]
+denylist = [
+# bzip2 feature transitivity
+"bz2_tokio",
+"bz2_static",
+
+# lzma feature transitivity
+"lzma_tokio",
+
+# flate2 feature transitivity
+"gz_zlib",
+"gz_zlib-ng-compat",
+"gz_cloudflare_zlib",
+"gz_rust_backend",
+
+# xz feature transitivity
+"xz_tokio"
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,8 @@ repository = "https://github.com/luizirber/niffler"
 homepage = "https://github.com/luizirber/niffler"
 readme = "README.md"
 documentation = "https://docs.rs/niffler"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56.1"
 
 [features]
 default = ["bz2", "lzma", "xz", "gz", "bgz", "zstd"]

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ it will throw a runtime error.
 
 ## Minimum supported Rust version
 
-Currently the minimum supported Rust version is 1.51.0.
+Currently the minimum supported Rust version is 1.56.1.
 
 ## Similar project
 

--- a/src/basic/compression.rs
+++ b/src/basic/compression.rs
@@ -14,7 +14,7 @@ pub use crate::level::Level;
 
 /* Format detection enum */
 /// `Format` represent a compression format of a file. Currently Gzip, Bzip, Lzma or No are supported.
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub enum Format {
     Gzip,
     Bzip,

--- a/src/level.rs
+++ b/src/level.rs
@@ -6,7 +6,7 @@
 ///  - `One` is convert in `bzip2::Compression::Fastest`,
 ///  - `Nine` in `bzip2::Compression::Best`
 /// and other value is convert in `bzip2::Compression::Default.
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Level {
     One,
     Two,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,19 @@
 //! even if any feature is disabled.
 //! But if you try to use `niffler::get_reader` for a disabled feature,
 //! it will throw a runtime error.
+//!
+//! ## Backends features
+//!
+//! The libraries that are used for decompression provide a number of features that can have a significant impact on performance.
+//! Here is the list of features available with corresponding backend crates and features name in backend crates:
+//! - bz2_tokio -> bzip2 tokio
+//! - bz2_static -> bzip2 static
+//! - lzma_tokio -> lzma tokio
+//! - gz_zlib -> flate2 zlib
+//! - gz_zlib-ng-compat -> flate2 zlib-ng-compat
+//! - gz_cloudflare_zlib -> flate2 cloudflare_zlib
+//! - gz_rust_backend -> flate2 rust_backend
+//! - xz_tokio -> xz2 tokio
 
 /* declare mod */
 pub mod basic;

--- a/src/seek/compression.rs
+++ b/src/seek/compression.rs
@@ -11,7 +11,7 @@ pub trait WriteSeek: io::Write + io::Seek {}
 impl<T> WriteSeek for T where T: io::Write + io::Seek {}
 
 /// `Format` represent a compression format of a file. Currently BGzip are supported.
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Format {
     BGzip,
     No,

--- a/src/seeksend/compression.rs
+++ b/src/seeksend/compression.rs
@@ -1,5 +1,5 @@
 /// `Format` represent a compression format of a file. Currently BGzip are supported.
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Format {
     BGzip,
     No,

--- a/src/send/compression.rs
+++ b/src/send/compression.rs
@@ -12,7 +12,7 @@ use crate::level::Level;
 
 /* Format detection enum */
 /// `Format` represent a compression format of a file. Currently Gzip, Bzip, Lzma or No are supported.
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Format {
     Gzip,
     Bzip,


### PR DESCRIPTION
To address issue #53 I add many features, to let user access to backend features.

It's seems the only way to let user access to backend features, I didn't see any way to do it automatically. 

I choose to use our feature name as prefix in place of package name but we can change this if you want @luizirber.

Todo:
- [x] Add documentation to explain this features