### PR TITLE
Update changelog for 2.7.0 release, upgrade CI

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,32 +11,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
 
       - name: Make sure we can publish the niffler crate
-        uses: actions-rs/cargo@v1
-        with:
-          command: publish
-          args: --dry-run --manifest-path ./Cargo.toml
+        run: |
+          cargo publish --dry-run --manifest-path ./Cargo.toml
 
       # Login to crates.io on tags
       - name: login to crates.io
-        uses: actions-rs/cargo@v1
-        with:
-          command: login
-          args: ${{ secrets.CRATES_IO_TOKEN }}
+        run: |
+          cargo login ${{ secrets.CRATES_IO_TOKEN }}
 
       # Publish to crates.io on tags
       - name: Publish to crates.io
-        uses: actions-rs/cargo@v1
-        with:
-          command: publish
-          args: --manifest-path ./Cargo.toml
-          
+        run: |
+          cargo publish --manifest-path ./Cargo.toml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,19 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
 
       - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
+        run: |
+          cargo check
 
   test:
     runs-on: ${{ matrix.os }}
@@ -46,34 +41,32 @@ jobs:
             os: ubuntu-latest
             rust: stable
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
+
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: taiki-e/install-action@nextest
 
       - name: Run tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --no-fail-fast --locked
+        run: |
+          cargo nextest run
 
   test_all_feature_combinations:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
 
-      - uses: actions-rs/install@v0.1
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: taiki-e/install-action@v2
         with:
-          crate: cargo-all-features
-          version: latest
-          use-tool-cache: true
+          tool: cargo-all-features
 
       - name: Run tests for all feature combinations
         run: cargo test-all-features --no-fail-fast --all --locked
@@ -81,89 +74,77 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: nightly
-          override: true
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
 
-      - name: Install cargo-tarpaulin
-        uses: actions-rs/install@v0.1
-        with:
-          crate: cargo-tarpaulin
-          version: latest
-          use-tool-cache: true
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - uses: taiki-e/install-action@nextest
 
-      - name: Run cargo-tarpaulin
-        run: cargo tarpaulin --locked --timeout 600 --out Xml -- --test-threads 1
+      - name: Collect coverage data
+        run: cargo llvm-cov nextest --lcov --output-path lcov.info
 
       - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v4
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   lints:
     name: Lints
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: rustfmt, clippy
+          components: "clippy, rustfmt"
+
+      - uses: Swatinem/rust-cache@v2
 
       - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: |
+          cargo fmt --all -- --check
 
       - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
+        run: |
+          cargo clippy --all -- -D warnings
 
   publish:
     name: Publish (dry-run)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - name: Make sure we can publish the crate
-        uses: actions-rs/cargo@v1
-        with:
-          command: publish
-          args: --dry-run
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
 
       - name: Check semver
         uses: obi1kenobi/cargo-semver-checks-action@v2
         with:
           feature-group: default-features
 
+      - name: Make sure we can publish the crate
+        run: |
+          cargo publish --dry-run
+
   minimum_rust_version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.74.0
-          override: true
+          toolchain: "1.74.0"
+
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: taiki-e/install-action@nextest
 
       - name: check if README matches MSRV defined here
         run: grep '1.74.0' README.md
@@ -172,24 +153,20 @@ jobs:
         run: grep 'rust-version = "1.74"' Cargo.toml
 
       - name: Run tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --no-fail-fast --locked
+        run: |
+          cargo nextest run
 
   wasm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          override: true
           target: wasm32-unknown-unknown
 
+      - uses: Swatinem/rust-cache@v2
+
       - name: Build on wasm
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --target wasm32-unknown-unknown --no-default-features --features gz
+        run: |
+          cargo build --target wasm32-unknown-unknown --no-default-features --features gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- CI: use cargo-semver-checks to verify breaking changes (#66)
-
 ### Changed
 
 ### Fixed
 
-## 2.6.0 - 2024-06-08
+## [2.7.0] - 2025-01-24
 
 ### Added
+
+- allow gz_lib-ng (without compat) (#69)
+- CI: use cargo-semver-checks to verify breaking changes (#66)
+
+## [2.6.0] - 2024-06-08
 
 ### Changed
 
@@ -130,7 +133,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rename crate from `ocf` to `niffler`
 - Import codebase from sourmash repo (which copied it from the yacrd repo)
 
-[unreleased]: https://github.com/luizirber/niffler/compare/v2.4.0...HEAD
+[unreleased]: https://github.com/luizirber/niffler/compare/v2.7.0...HEAD
+[2.7.0]: https://github.com/luizirber/niffler/compare/v2.6.0..v2.7.0
+[2.6.0]: https://github.com/luizirber/niffler/compare/v2.5.0..v2.6.0
+[2.5.0]: https://github.com/luizirber/niffler/compare/v2.4.0..v2.5.0
 [2.4.0]: https://github.com/luizirber/niffler/compare/v2.3.2..v2.4.0
 [2.3.2]: https://github.com/luizirber/niffler/compare/v2.3.1..v2.3.2
 [2.3.1]: https://github.com/luizirber/niffler/compare/v2.3.0..v2.3.1


### PR DESCRIPTION
- Update changelog for 2.7.0 release
- Replace unsupported CI actions with supported ones
- Use nextest and llvm-cov in CI